### PR TITLE
Resolve button issue on the recipeSearch screen

### DIFF
--- a/WhatToEat/Views/RecipeSearchPage.xaml
+++ b/WhatToEat/Views/RecipeSearchPage.xaml
@@ -33,6 +33,8 @@
                 <DataTemplate>
                     <Grid HandlerChanged="OnImageHandlerChanged" 
                           HeightRequest="220" 
+			  AutomationProperties.IsInAccessibleTree="True"
+			  SemanticProperties.Description="{Binding Recipe.RecipeName}"
                           RowDefinitions="*" 
                           ColumnDefinitions="*">
                         <Grid.GestureRecognizers>


### PR DESCRIPTION
Try this to fix iOS alternate solution would be to remove the gesture recognizer on the Grid and set SelectionMode on the CollectionView to single and see if that works