### PR TITLE
Delete line and use macro

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -18,6 +18,7 @@
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" protocolVersion="3" />
     <add key="dotnet6" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
     <add key="dotnet7" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json" />
+    <add key="dotnet8" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json" />
     <add key="skiasharp" value="https://pkgs.dev.azure.com/xamarin/public/_packaging/SkiaSharp/nuget/v3/index.json" />
     <add key="wasdk-internal" value="https://pkgs.dev.azure.com/microsoft/ProjectReunion/_packaging/Project.Reunion.nuget.internal/nuget/v3/index.json" />
   </packageSources>

--- a/WhatToEat/Platforms/Windows/Package.appxmanifest
+++ b/WhatToEat/Platforms/Windows/Package.appxmanifest
@@ -46,7 +46,6 @@
             <uap:ShowOn Tile="wide310x150Logo"/>
           </uap:ShowNameOnTiles>
         </uap:DefaultTile >
-        <uap:SplashScreen Image="app_logo.png" />
       </uap:VisualElements>
     </Application>
   </Applications>

--- a/WhatToEat/ViewModels/MyRecipesViewModel.cs
+++ b/WhatToEat/ViewModels/MyRecipesViewModel.cs
@@ -46,10 +46,15 @@ namespace Recipes.ViewModels
                 IsBusy = false;
             }
 
-			MessagingCenter.Send(this, "RemoveRecipeFromVirtualListView");
-		}
 
-        public void OnAppearing()
+            #if NET8_0_OR_GREATER
+                    CommunityToolkit.Mvvm.Messaging.WeakReferenceMessenger.Default.Send(this, "RemoveRecipeFromVirtualListView"); 
+            #else
+                    MessagingCenter.Send(this, "RemoveRecipeFromVirtualListView");
+            #endif
+        }
+
+            public void OnAppearing()
         {
             IsBusy = true;
             SelectedItem = null;


### PR DESCRIPTION
Fix issue:
#1: Debug on Windows will meet the error:  Error DEP0700: Registration of the app failed.
For #1, we can just delete that line from the manifest file. The file app_logo.png does not exist in the project.

#2: In .NET 8 Build project will meet the Error CS0122 'MessagingCenter' is inaccessible due to its protection level.
For #2, we can use a macro like in this example:
![image](https://github.com/rachelkang/recipeSearch/assets/91244512/2e33f080-7210-488f-8a18-2453c01cdad3)
