### PR TITLE
[net9.0] Updating the project to .NET9 and trim/AOT compatibilty

### DIFF
--- a/WhatToEat/RecipeData.cs
+++ b/WhatToEat/RecipeData.cs
@@ -39,4 +39,12 @@ namespace Recipes
         [JsonPropertyName("url")]
         public string RecipeUrl { get; set; }
     }
+
+    [JsonSourceGenerationOptions(WriteIndented = true)]
+    [JsonSerializable(typeof(RecipeData))]
+    [JsonSerializable(typeof(Hit))]
+    [JsonSerializable(typeof(Recipe))]
+    internal partial class SourceGenerationContext : JsonSerializerContext
+    {
+    }
 }

--- a/WhatToEat/Recipes.csproj
+++ b/WhatToEat/Recipes.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<MajorFrameworkVersion>8.0</MajorFrameworkVersion>
+		<MajorFrameworkVersion>9.0</MajorFrameworkVersion>
     <TargetFrameworks>net$(MajorFrameworkVersion)-android;net$(MajorFrameworkVersion)-ios;net$(MajorFrameworkVersion)-maccatalyst</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net$(MajorFrameworkVersion)-windows10.0.19041.0</TargetFrameworks>
 		<OutputType>Exe</OutputType>

--- a/WhatToEat/Recipes.csproj
+++ b/WhatToEat/Recipes.csproj
@@ -21,9 +21,9 @@
 		<!-- Required for C# Hot Reload -->
 		<UseInterpreter Condition="'$(Configuration)' == 'Debug'">True</UseInterpreter>
 
-		<SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net8.0-ios'">13.6</SupportedOSPlatformVersion>
-		<SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net8.0-maccatalyst'">14.0</SupportedOSPlatformVersion>
-		<SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net8.0-android'">21.0</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net$(MajorFrameworkVersion)-ios'">13.6</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net$(MajorFrameworkVersion)-maccatalyst'">15.0</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net$(MajorFrameworkVersion)-android'">21.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$(TargetFramework.Contains('-windows'))">10.0.17763.0</SupportedOSPlatformVersion>
 		<TargetPlatformMinVersion Condition="$(TargetFramework.Contains('-windows'))">10.0.17763.0</TargetPlatformMinVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>

--- a/WhatToEat/Recipes.csproj
+++ b/WhatToEat/Recipes.csproj
@@ -2,8 +2,8 @@
 
 	<PropertyGroup>
 		<MajorFrameworkVersion>9.0</MajorFrameworkVersion>
-    <TargetFrameworks>net$(MajorFrameworkVersion)-android;net$(MajorFrameworkVersion)-ios;net$(MajorFrameworkVersion)-maccatalyst</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net$(MajorFrameworkVersion)-windows10.0.19041.0</TargetFrameworks>
+		<TargetFrameworks>net$(MajorFrameworkVersion)-android;net$(MajorFrameworkVersion)-ios;net$(MajorFrameworkVersion)-maccatalyst</TargetFrameworks>
+		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net$(MajorFrameworkVersion)-windows10.0.19041.0</TargetFrameworks>
 		<OutputType>Exe</OutputType>
 		<SingleProject>true</SingleProject>
 		<ImplicitUsings>enable</ImplicitUsings>
@@ -15,8 +15,8 @@
 		<ApplicationVersion>2</ApplicationVersion>
 		<DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
 
-    <!-- Required for running on iPhone device -->
-    <!--<RuntimeIdentifier Condition=" $(TargetFramework.Contains('-ios')) ">ios-arm64</RuntimeIdentifier>-->
+		<!-- Required for running on iPhone device -->
+		<!--<RuntimeIdentifier Condition=" $(TargetFramework.Contains('-ios')) ">ios-arm64</RuntimeIdentifier>-->
 
 		<!-- Required for C# Hot Reload -->
 		<UseInterpreter Condition="'$(Configuration)' == 'Debug'">True</UseInterpreter>
@@ -29,10 +29,14 @@
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
 	</PropertyGroup>
 
-  <ItemGroup Condition="$(MajorFrameworkVersion) >= 8.0">
-    <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
-    <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
-  </ItemGroup>
+	<PropertyGroup>
+		<JsonSerializerIsReflectionEnabledByDefault>false</JsonSerializerIsReflectionEnabledByDefault>
+	</PropertyGroup>
+
+	<ItemGroup Condition="$(MajorFrameworkVersion) >= 8.0">
+		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
+		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
+	</ItemGroup>
 
 	<ItemGroup>
 		<MauiIcon ForegroundFile="Resources\AppIcon\appicon.png" Include="Resources\AppIcon\appicon.png" Color="#2BB0ED" />

--- a/WhatToEat/RestService.cs
+++ b/WhatToEat/RestService.cs
@@ -27,7 +27,7 @@ namespace Recipes
                 if (response.IsSuccessStatusCode)
                 {
                     string content = await response.Content.ReadAsStringAsync();
-                    recipeData = JsonSerializer.Deserialize<RecipeData>(content);
+                    recipeData = JsonSerializer.Deserialize(content, SourceGenerationContext.Default.RecipeData);
                 }
             }
             catch (Exception ex)

--- a/WhatToEat/ViewModels/EditRecipeViewModel.cs
+++ b/WhatToEat/ViewModels/EditRecipeViewModel.cs
@@ -3,8 +3,7 @@ using Recipes.Models;
 
 namespace Recipes.ViewModels
 {
-    [QueryProperty(nameof(Id), nameof(Id))]
-    public class EditRecipeViewModel : BaseViewModel
+    public class EditRecipeViewModel : BaseViewModel, IQueryAttributable
     {
         string _id;
         string _recipeName;
@@ -24,6 +23,18 @@ namespace Recipes.ViewModels
                 (_, __) => UpdateCommand.ChangeCanExecute();
             PropertyChanged +=
                 (_, __) => DeleteCommand.ChangeCanExecute();
+        }
+
+        public void ApplyQueryAttributes(IDictionary<string, object> query)
+        {
+            if (query.TryGetValue(nameof(Id), out object id))
+            {
+                Id = System.Net.WebUtility.UrlDecode((string)id);
+            }
+            else
+            {
+                Id = string.Empty;
+            }
         }
 
         private bool ValidateUpdate()

--- a/WhatToEat/ViewModels/RecipeDetailViewModel.cs
+++ b/WhatToEat/ViewModels/RecipeDetailViewModel.cs
@@ -5,8 +5,7 @@ using Recipes.Models;
 
 namespace Recipes.ViewModels
 {
-    [QueryProperty(nameof(ItemId), nameof(ItemId))]
-    public class RecipeDetailViewModel : BaseViewModel
+    public class RecipeDetailViewModel : BaseViewModel, IQueryAttributable
     {
         public Command EditRecipeCommand { get; }
 
@@ -46,6 +45,18 @@ namespace Recipes.ViewModels
             RecipeBodyVisible = true;
             RecipeUrlVisible = true;
             RecipeReviewVisible = false;
+        }
+
+        public void ApplyQueryAttributes(IDictionary<string, object> query)
+        {
+            if (query.TryGetValue(nameof(ItemId), out object itemId))
+            {
+                ItemId = System.Net.WebUtility.UrlDecode((string)itemId);
+            }
+            else
+            {
+                ItemId = string.Empty;
+            }
         }
 
 		public string ItemId

--- a/WhatToEat/ViewModels/SearchResultDetailViewModel.cs
+++ b/WhatToEat/ViewModels/SearchResultDetailViewModel.cs
@@ -5,8 +5,7 @@ using System.Collections.ObjectModel;
 
 namespace Recipes.ViewModels
 {
-	[QueryProperty(nameof(HitId), nameof(HitId))]
-    public class SearchResultDetailViewModel : BaseViewModel
+    public class SearchResultDetailViewModel : BaseViewModel, IQueryAttributable
     {
         public Hit Hit { get; set; }
 
@@ -39,6 +38,18 @@ namespace Recipes.ViewModels
 			RecipeBodyVisible = true;
 			RecipeUrlVisible = true;
 		}
+
+        public void ApplyQueryAttributes(IDictionary<string, object> query)
+        {
+            if (query.TryGetValue(nameof(HitId), out object hitId))
+            {
+                HitId = System.Net.WebUtility.UrlDecode((string)hitId);
+            }
+            else
+            {
+                HitId = string.Empty;
+            }
+        }
 
 		public string RecipeName
         {

--- a/WhatToEat/ViewModels/SearchResultsViewModel.cs
+++ b/WhatToEat/ViewModels/SearchResultsViewModel.cs
@@ -1,10 +1,8 @@
-﻿using Recipes.Views;
+using Recipes.Views;
 
 namespace Recipes.ViewModels
 {
-    [QueryProperty(nameof(SearchQuery), nameof(SearchQuery))]
-    [QueryProperty(nameof(SearchFilter), nameof(SearchFilter))]
-    public class SearchResultsViewModel : BaseViewModel
+    public class SearchResultsViewModel : BaseViewModel, IQueryAttributable
     {
         RestService _restService;
 
@@ -29,6 +27,27 @@ namespace Recipes.ViewModels
             SearchCommand = new Command(async () => await OnSearch());
 
 		}
+
+        public void ApplyQueryAttributes(IDictionary<string, object> query)
+        {
+            if (query.TryGetValue(nameof(SearchQuery), out object searchQuery))
+            {
+                SearchQuery = System.Net.WebUtility.UrlDecode((string)searchQuery);
+            }
+            else
+            {
+                SearchQuery = string.Empty;
+            }
+
+            if (query.TryGetValue(nameof(SearchFilter), out object searchFilter))
+            {
+                SearchFilter = System.Net.WebUtility.UrlDecode((string)searchFilter);
+            }
+            else
+            {
+                SearchFilter = string.Empty;
+            }
+        }
 
         public RecipeData RecipeData
         {

--- a/WhatToEat/Views/EditItemPage.xaml
+++ b/WhatToEat/Views/EditItemPage.xaml
@@ -1,9 +1,11 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:local="clr-namespace:Recipes.ViewModels"
              x:Class="Recipes.Views.EditItemPage"
              Shell.PresentationMode="ModalAnimated"
-             Visual="Material">
+             Visual="Material"
+             x:DataType="local:EditRecipeViewModel">
     <ContentPage.Content>
         <Grid Margin="20,30,20,20">
             <Grid.ColumnDefinitions>
@@ -18,13 +20,13 @@
             <Label FontSize="25" FontAttributes="Bold" Text="Edit recipe" Style="{StaticResource RecipeItemLabelStyle}" Margin="15" SemanticProperties.HeadingLevel="Level1"/>
             <StackLayout Grid.Row="1" Margin="15,0">
                 <Label x:Name="recipeNameLabel" Text="Recipe Name" Style="{StaticResource RecipeItemLabelStyle}"/>
-                <Entry SemanticProperties.Description="{Binding Source={x:Reference recipeNameLabel},Path=Text}" Text="{Binding RecipeName, Mode=TwoWay}" IsSpellCheckEnabled="false" Margin="0,0,0,10" MinimumHeightRequest="50"/>
+                <Entry SemanticProperties.Description="{Binding Source={x:Reference recipeNameLabel}, Path=Text, x:DataType=Label}" Text="{Binding RecipeName, Mode=TwoWay}" IsSpellCheckEnabled="false" Margin="0,0,0,10" MinimumHeightRequest="50"/>
                 <Label x:Name="imageUrlLabel" Text="Image URL" Style="{StaticResource RecipeItemLabelStyle}"/>
-                <Entry SemanticProperties.Description="{Binding Source={x:Reference imageUrlLabel},Path=Text}" Text="{Binding ImageUrl, Mode=TwoWay}" IsSpellCheckEnabled="false" Margin="0,0,0,10" MinimumHeightRequest="50"/>
+                <Entry SemanticProperties.Description="{Binding Source={x:Reference imageUrlLabel}, Path=Text, x:DataType=Label}" Text="{Binding ImageUrl, Mode=TwoWay}" IsSpellCheckEnabled="false" Margin="0,0,0,10" MinimumHeightRequest="50"/>
                 <Label x:Name="ingredientsLabel" Text="Ingredients" Style="{StaticResource RecipeItemLabelStyle}"/>
-                <Editor SemanticProperties.Description="{Binding Source={x:Reference ingredientsLabel},Path=Text}" Text="{Binding Ingredients, Mode=TwoWay}" AutoSize="TextChanges" IsSpellCheckEnabled="false" Margin="0,0,0,10" MinimumHeightRequest="50"/>
+                <Editor SemanticProperties.Description="{Binding Source={x:Reference ingredientsLabel}, Path=Text, x:DataType=Label}" Text="{Binding Ingredients, Mode=TwoWay}" AutoSize="TextChanges" IsSpellCheckEnabled="false" Margin="0,0,0,10" MinimumHeightRequest="50"/>
                 <Label x:Name="recipeLabel" Text="Recipe" Style="{StaticResource RecipeItemLabelStyle}"/>
-                <Editor SemanticProperties.Description="{Binding Source={x:Reference recipeLabel},Path=Text}" Text="{Binding RecipeBody, Mode=TwoWay}" AutoSize="TextChanges" IsSpellCheckEnabled="false" Margin="0,0,0,10" MinimumHeightRequest="50"/>
+                <Editor SemanticProperties.Description="{Binding Source={x:Reference recipeLabel}, Path=Text, x:DataType=Label}" Text="{Binding RecipeBody, Mode=TwoWay}" AutoSize="TextChanges" IsSpellCheckEnabled="false" Margin="0,0,0,10" MinimumHeightRequest="50"/>
                 <Label FontSize="Small" FormattedText="{Binding RecipeUrl}" FontAttributes="Italic" />
             </StackLayout>
             <FlexLayout Grid.Row="2" AlignItems="Center" JustifyContent="SpaceEvenly">

--- a/WhatToEat/Views/EditRecipePage.xaml
+++ b/WhatToEat/Views/EditRecipePage.xaml
@@ -1,9 +1,11 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:local="clr-namespace:Recipes.ViewModels"
              x:Class="Recipes.Views.EditRecipePage"
              Shell.PresentationMode="ModalAnimated"
-             Visual="Material">
+             Visual="Material"
+             x:DataType="local:EditRecipeViewModel">
     <ContentPage.Content>
         <Grid Margin="20,30,20,20">
             <Grid.ColumnDefinitions>
@@ -28,11 +30,11 @@
                     </Label>
                     <Entry x:Name="recipeNameEntry" Placeholder="Recipe Name, Required field" Text="{Binding RecipeName, Mode=TwoWay}" IsSpellCheckEnabled="false" Margin="0,0,0,10" MinimumHeightRequest="50"/>
                     <Label x:Name="imageUrlLabel" Text="Image URL" Style="{StaticResource RecipeItemLabelStyle}"/>
-                    <Entry Placeholder="{Binding Source={x:Reference imageUrlLabel},Path=Text}" Text="{Binding ImageUrl, Mode=TwoWay}" IsSpellCheckEnabled="false" Margin="0,0,0,10" MinimumHeightRequest="50"/>
+                    <Entry Placeholder="{Binding Source={x:Reference imageUrlLabel}, Path=Text, x:DataType=Label}" Text="{Binding ImageUrl, Mode=TwoWay}" IsSpellCheckEnabled="false" Margin="0,0,0,10" MinimumHeightRequest="50"/>
                     <Label x:Name="ingredientsLabel" Text="Ingredients" Style="{StaticResource RecipeItemLabelStyle}"/>
-                    <Editor Placeholder="{Binding Source={x:Reference ingredientsLabel},Path=Text}" Text="{Binding Ingredients, Mode=TwoWay}" AutoSize="TextChanges" IsSpellCheckEnabled="false" Margin="0,0,0,10" MinimumHeightRequest="50"/>
+                    <Editor Placeholder="{Binding Source={x:Reference ingredientsLabel}, Path=Text, x:DataType=Label}" Text="{Binding Ingredients, Mode=TwoWay}" AutoSize="TextChanges" IsSpellCheckEnabled="false" Margin="0,0,0,10" MinimumHeightRequest="50"/>
                     <Label x:Name="recipeLabel" Text="Recipe" Style="{StaticResource RecipeItemLabelStyle}"/>
-                    <Editor Placeholder="{Binding Source={x:Reference recipeLabel},Path=Text}" Text="{Binding RecipeBody, Mode=TwoWay}" IsSpellCheckEnabled="false" Margin="0,0,0,10" MinimumHeightRequest="50"/>
+                    <Editor Placeholder="{Binding Source={x:Reference recipeLabel}, Path=Text, x:DataType=Label}" Text="{Binding RecipeBody, Mode=TwoWay}" IsSpellCheckEnabled="false" Margin="0,0,0,10" MinimumHeightRequest="50"/>
                     <Label FontSize="Small" FormattedText="{Binding RecipeUrl}" FontAttributes="Italic" />
                     <Grid>
                         <Grid.ColumnDefinitions>
@@ -43,7 +45,7 @@
                             <RowDefinition Height="*" />
                         </Grid.RowDefinitions>
                         <Label x:Name="reviewLabel" Text="Review" Style="{StaticResource RecipeItemLabelStyle}"/>
-                        <Label Grid.Column="1" x:Name="ratingLabel" Text="{Binding Source={x:Reference ratingSlider}, Path=Value, StringFormat='{0:F1} / 10 ★'}" HorizontalOptions="Center" Style="{StaticResource RecipeItemLabelStyle}" SemanticProperties.Description="{Binding RecipeRating, StringFormat='{0:F1} out of 10 stars'}" />
+                        <Label Grid.Column="1" x:Name="ratingLabel" Text="{Binding Source={x:Reference ratingSlider}, Path=Value, StringFormat='{0:F1} / 10 ★', x:DataType=Slider}" HorizontalOptions="Center" Style="{StaticResource RecipeItemLabelStyle}" SemanticProperties.Description="{Binding RecipeRating, StringFormat='{0:F1} out of 10 stars'}" />
                     </Grid>
                     <Grid Margin="0,10">
                         <Grid.ColumnDefinitions>
@@ -53,13 +55,13 @@
                         <Grid.RowDefinitions>
                             <RowDefinition Height="*" />
                         </Grid.RowDefinitions>
-                        <Slider x:Name="ratingSlider" SemanticProperties.Description="Review" SemanticProperties.Hint="Rate out of ten stars" Value="{Binding Source={x:Reference ratingStepper}, Path=Value}" Minimum="0" Maximum="10" ThumbColor="{AppThemeBinding Dark=White, Light={StaticResource Primary}}" MinimumTrackColor="{AppThemeBinding Dark=White, Light={StaticResource Primary}}" MaximumTrackColor="Gray" VerticalOptions="Center" ValueChanged="OnValueChanged"/>
+                        <Slider x:Name="ratingSlider" SemanticProperties.Description="Review" SemanticProperties.Hint="Rate out of ten stars" Value="{Binding Source={x:Reference ratingStepper}, Path=Value, x:DataType=Stepper}" Minimum="0" Maximum="10" ThumbColor="{AppThemeBinding Dark=White, Light={StaticResource Primary}}" MinimumTrackColor="{AppThemeBinding Dark=White, Light={StaticResource Primary}}" MaximumTrackColor="Gray" VerticalOptions="Center" ValueChanged="OnValueChanged"/>
                         <StackLayout Grid.Column="1">
                             <Stepper x:Name="ratingStepper" Value="{Binding RecipeRating, Mode=TwoWay}" Minimum="0" Maximum="10" Increment="0.1" VerticalOptions="Center" ValueChanged="OnValueChanged" />
                         </StackLayout>
                         
                     </Grid>
-                    <Editor SemanticProperties.Description="{Binding Source={x:Reference reviewLabel},Path=Text}" Text="{Binding RecipeReview, Mode=TwoWay}" AutoSize="TextChanges" IsSpellCheckEnabled="false" Margin="0,0,0,10" MinimumHeightRequest="50" />
+                    <Editor SemanticProperties.Description="{Binding Source={x:Reference reviewLabel}, Path=Text, x:DataType=Label}" Text="{Binding RecipeReview, Mode=TwoWay}" AutoSize="TextChanges" IsSpellCheckEnabled="false" Margin="0,0,0,10" MinimumHeightRequest="50" />
                 </StackLayout>
             </ScrollView>
             <FlexLayout Grid.Row="2" AlignItems="Center" JustifyContent="SpaceEvenly">

--- a/WhatToEat/Views/MyRecipesPage.xaml
+++ b/WhatToEat/Views/MyRecipesPage.xaml
@@ -2,17 +2,18 @@
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="Recipes.Views.MyRecipesPage"
-             Title="{Binding Title}"
              xmlns:ios="clr-namespace:Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific;assembly=Microsoft.Maui.Controls"
              xmlns:vm="clr-namespace:Recipes.ViewModels"
-             xmlns:local="clr-namespace:Recipes">
+             xmlns:models="clr-namespace:Recipes.Models"
+             xmlns:local="clr-namespace:Recipes"
+             Title="{Binding Title, x:DataType=vm:MyRecipesViewModel}">
     <ContentPage.Resources>
         <ResourceDictionary>
             <local:EvenIndexBackgroundConverter x:Key="evenIndexBackgroundConverter" />
         </ResourceDictionary>
     </ContentPage.Resources>
     <ContentPage.ToolbarItems>
-        <ToolbarItem Text="New" Command="{Binding NewRecipeCommand}" />
+        <ToolbarItem Text="New" Command="{Binding NewRecipeCommand, x:DataType=vm:MyRecipesViewModel}" />
     </ContentPage.ToolbarItems>
     <StackLayout Margin="20">
         <Label Text="Your recipes" SemanticProperties.HeadingLevel="Level1" FontSize="30" FontAttributes="Bold" />
@@ -22,8 +23,9 @@
             HeightRequest="570"
 			HorizontalOptions="Fill"
 			VerticalOptions="Fill"
-            ItemsSource="{Binding Items}"
-            Loop="False">
+            ItemsSource="{Binding Items, x:DataType=vm:MyRecipesViewModel}"
+            Loop="False"
+            x:DataType="models:Item">
             <CarouselView.ItemTemplate>
                 <DataTemplate>
                     <Grid RowDefinitions="*" 

--- a/WhatToEat/Views/NewRecipePage.xaml
+++ b/WhatToEat/Views/NewRecipePage.xaml
@@ -1,10 +1,12 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:local="clr-namespace:Recipes.ViewModels"
              x:Class="Recipes.Views.NewRecipePage"
              Shell.PresentationMode="ModalAnimated"
              Title="New Recipe"
-             Visual="Material">
+             Visual="Material"
+             x:DataType="local:NewRecipeViewModel">
     <ContentPage.Content>
         <Grid Margin="20,30,20,20">
             <Grid.ColumnDefinitions>
@@ -29,11 +31,11 @@
                     </Label>
                     <Entry x:Name="recipeNameEntry" Placeholder="Recipe Name, Required field" Text="{Binding RecipeName, Mode=TwoWay}" IsSpellCheckEnabled="false" Margin="0,0,0,10" MinimumHeightRequest="50"/>
                     <Label x:Name="imageUrlLabel" Text="Image URL" Style="{StaticResource RecipeItemLabelStyle}"/>
-                    <Entry Placeholder="{Binding Source={x:Reference imageUrlLabel},Path=Text}" Text="{Binding ImageUrl, Mode=TwoWay}" IsSpellCheckEnabled="false" Margin="0,0,0,10" MinimumHeightRequest="50"/>
+                    <Entry Placeholder="{Binding Source={x:Reference imageUrlLabel}, Path=Text, x:DataType=Label}" Text="{Binding ImageUrl, Mode=TwoWay}" IsSpellCheckEnabled="false" Margin="0,0,0,10" MinimumHeightRequest="50"/>
                     <Label x:Name="ingredientsLabel" Text="Ingredients" Style="{StaticResource RecipeItemLabelStyle}"/>
-                    <Editor Placeholder="{Binding Source={x:Reference ingredientsLabel},Path=Text}" Text="{Binding Ingredients, Mode=TwoWay}" AutoSize="TextChanges" IsSpellCheckEnabled="false" Margin="0,0,0,10" MinimumHeightRequest="50"/>
+                    <Editor Placeholder="{Binding Source={x:Reference ingredientsLabel}, Path=Text, x:DataType=Label}" Text="{Binding Ingredients, Mode=TwoWay}" AutoSize="TextChanges" IsSpellCheckEnabled="false" Margin="0,0,0,10" MinimumHeightRequest="50"/>
                     <Label x:Name="recipeLabel" Text="Recipe" Style="{StaticResource RecipeItemLabelStyle}"/>
-                    <Editor Placeholder="{Binding Source={x:Reference recipeLabel},Path=Text}" Text="{Binding RecipeBody, Mode=TwoWay}" AutoSize="TextChanges" IsSpellCheckEnabled="false" Margin="0,0,0,10" MinimumHeightRequest="50"/>
+                    <Editor Placeholder="{Binding Source={x:Reference recipeLabel}, Path=Text, x:DataType=Label}" Text="{Binding RecipeBody, Mode=TwoWay}" AutoSize="TextChanges" IsSpellCheckEnabled="false" Margin="0,0,0,10" MinimumHeightRequest="50"/>
 
                     <Grid>
                         <Grid.ColumnDefinitions>
@@ -44,7 +46,7 @@
                             <RowDefinition Height="*" />
                         </Grid.RowDefinitions>
                         <Label x:Name="reviewLabel" Text="Review" Style="{StaticResource RecipeItemLabelStyle}"/>
-                        <Label Grid.Column="1" x:Name="ratingLabel" Text="{Binding Source={x:Reference ratingSlider}, Path=Value, StringFormat='{0:F1} / 10 ★'}" HorizontalOptions="Center" Style="{StaticResource RecipeItemLabelStyle}" SemanticProperties.Description="{Binding RecipeRating, StringFormat='{0:F1} out of 10 stars'}" />
+                        <Label Grid.Column="1" x:Name="ratingLabel" Text="{Binding Source={x:Reference ratingSlider}, Path=Value, StringFormat='{0:F1} / 10 ★', x:DataType=Slider}" HorizontalOptions="Center" Style="{StaticResource RecipeItemLabelStyle}" SemanticProperties.Description="{Binding RecipeRating, StringFormat='{0:F1} out of 10 stars'}" />
                     </Grid>
                     <Grid Margin="0,10">
                         <Grid.ColumnDefinitions>
@@ -54,10 +56,10 @@
                         <Grid.RowDefinitions>
                             <RowDefinition Height="*" />
                         </Grid.RowDefinitions>
-                        <Slider x:Name="ratingSlider" SemanticProperties.Description="Review" SemanticProperties.Hint="Rate out of ten stars" Value="{Binding Source={x:Reference ratingStepper}, Path=Value}" Minimum="0" Maximum="10" ThumbColor="{AppThemeBinding Dark=White, Light={StaticResource Primary}}" MinimumTrackColor="{AppThemeBinding Dark=White, Light={StaticResource Primary}}" MaximumTrackColor="Gray" VerticalOptions="Center" ValueChanged="OnValueChanged"/>
+                        <Slider x:Name="ratingSlider" SemanticProperties.Description="Review" SemanticProperties.Hint="Rate out of ten stars" Value="{Binding Source={x:Reference ratingStepper}, Path=Value, x:DataType=Stepper}" Minimum="0" Maximum="10" ThumbColor="{AppThemeBinding Dark=White, Light={StaticResource Primary}}" MinimumTrackColor="{AppThemeBinding Dark=White, Light={StaticResource Primary}}" MaximumTrackColor="Gray" VerticalOptions="Center" ValueChanged="OnValueChanged"/>
                         <Stepper Grid.Column="1" x:Name="ratingStepper" Value="{Binding RecipeRating, Mode=TwoWay}" Minimum="0" Maximum="10" Increment="0.1" VerticalOptions="Center" ValueChanged="OnValueChanged" />
                     </Grid>
-                    <Editor SemanticProperties.Description="{Binding Source={x:Reference reviewLabel},Path=Text}" Text="{Binding RecipeReview, Mode=TwoWay}" AutoSize="TextChanges" IsSpellCheckEnabled="false" Margin="0,0,0,10" MinimumHeightRequest="50" />
+                    <Editor SemanticProperties.Description="{Binding Source={x:Reference reviewLabel}, Path=Text, x:DataType=Label}" Text="{Binding RecipeReview, Mode=TwoWay}" AutoSize="TextChanges" IsSpellCheckEnabled="false" Margin="0,0,0,10" MinimumHeightRequest="50" />
                 </StackLayout>
             </ScrollView>
             <FlexLayout Grid.Row="2" AlignItems="Center" JustifyContent="SpaceEvenly">

--- a/WhatToEat/Views/RecipeDetailPage.xaml
+++ b/WhatToEat/Views/RecipeDetailPage.xaml
@@ -2,6 +2,9 @@
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="Recipes.Views.RecipeDetailPage"
+             xmlns:vm="clr-namespace:Recipes.ViewModels"
+             xmlns:models="clr-namespace:Recipes.Models"
+             x:DataType="vm:RecipeDetailViewModel"
              Title="{Binding Title}">
     <ContentPage.ToolbarItems>
         <ToolbarItem Text="Edit" Command="{Binding EditRecipeCommand}" />
@@ -25,8 +28,8 @@
                     <BindableLayout.ItemTemplate>
                         <DataTemplate>
                             <StackLayout Orientation="Horizontal">
-                                <CheckBox SemanticProperties.Description="{Binding IngredientItem}" Color="{AppThemeBinding Dark=White, Light={StaticResource Primary}}" IsChecked="{Binding IngredientChecked}" HeightRequest="50" WidthRequest="50"/>
-                                <Label AutomationProperties.IsInAccessibleTree="False" Text="{Binding IngredientItem}"  VerticalOptions="Center"/>
+                                <CheckBox SemanticProperties.Description="{Binding IngredientItem, x:DataType=models:Ingredient}" Color="{AppThemeBinding Dark=White, Light={StaticResource Primary}}" IsChecked="{Binding IngredientChecked}" HeightRequest="50" WidthRequest="50"/>
+                                <Label AutomationProperties.IsInAccessibleTree="False" Text="{Binding IngredientItem, x:DataType=models:Ingredient}"  VerticalOptions="Center"/>
                             </StackLayout>
                         </DataTemplate>
                     </BindableLayout.ItemTemplate>

--- a/WhatToEat/Views/SearchResultDetailPage.xaml
+++ b/WhatToEat/Views/SearchResultDetailPage.xaml
@@ -2,6 +2,8 @@
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:xct="http://xamarin.com/schemas/2020/toolkit" x:Class="Recipes.Views.SearchResultDetailPage"
+             xmlns:vm="clr-namespace:Recipes.ViewModels"
+             x:DataType="vm:SearchResultDetailViewModel"
              Title="{Binding Title}"
              Visual="Material"
              xmlns:ios="clr-namespace:Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific;assembly=Microsoft.Maui.Controls"

--- a/WhatToEat/Views/SearchResultsPage.xaml
+++ b/WhatToEat/Views/SearchResultsPage.xaml
@@ -4,6 +4,8 @@
              x:Class="Recipes.Views.SearchResultsPage"
              xmlns:ios="clr-namespace:Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific;assembly=Microsoft.Maui.Controls"
              xmlns:vm="clr-namespace:Recipes.ViewModels"
+             xmlns:recipes="clr-namespace:Recipes"
+             x:DataType="vm:SearchResultsViewModel"
              Title="{Binding Title}" xmlns:local="clr-namespace:Recipes">
 
     <Grid RowDefinitions="Auto,Auto,*" Margin="5,5,5,0" HandlerChanged="OnImageHandlerChanged" >
@@ -13,7 +15,7 @@
                    Placeholder="Search recipes"
                    Text="{Binding SearchQuery}"
                    SearchCommand="{Binding SearchCommand}"
-                   SearchCommandParameter="{Binding Text, Source={x:Reference searchBar}}"/>
+                   SearchCommandParameter="{Binding Text, Source={x:Reference searchBar}, x:DataType=SearchBar}"/>
         
         <Label Grid.Row="1" Text="{Binding NoResultsLabel}" IsVisible="{Binding NoResultsLabelVisible}" Padding="20,10,20,0" HorizontalTextAlignment="Center" FontAttributes="Italic"/>
 
@@ -31,21 +33,21 @@
             </CollectionView.ItemsLayout>
             <CollectionView.ItemTemplate>
                 <DataTemplate>
-                    <Grid SemanticProperties.Description="{Binding Recipe.RecipeName}"
+                    <Grid SemanticProperties.Description="{Binding Recipe.RecipeName, x:DataType=recipes:Hit}"
                           HandlerChanged="OnImageHandlerChanged" 
                           HeightRequest="220"
                           RowDefinitions="*" 
                           ColumnDefinitions="*">
 
                         <Grid>
-                            <Image Source="{Binding Recipe.ImageUrl}" Aspect="AspectFill" VerticalOptions="Fill" HorizontalOptions="Fill" AutomationProperties.IsInAccessibleTree="False"/>
+                            <Image Source="{Binding Recipe.ImageUrl, x:DataType=recipes:Hit}" Aspect="AspectFill" VerticalOptions="Fill" HorizontalOptions="Fill" AutomationProperties.IsInAccessibleTree="False"/>
                             <Label x:Name="recipeName"
                                    Padding="5"
                                    HorizontalOptions="Fill" 
                                    VerticalOptions="End"
                                    VerticalTextAlignment="Start"
                                    HorizontalTextAlignment="Center"
-                                   Text="{Binding Recipe.RecipeName}"
+                                   Text="{Binding Recipe.RecipeName, x:DataType=recipes:Hit}"
                                    Style="{StaticResource RecipeNameStyle}"
                                    LineBreakMode="WordWrap" 
                                    MaxLines="2"

--- a/WhatToEat/Views/StartingPage.xaml
+++ b/WhatToEat/Views/StartingPage.xaml
@@ -3,6 +3,8 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="Recipes.Views.StartingPage"
              xmlns:ios="clr-namespace:Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific;assembly=Microsoft.Maui.Controls"
+             xmlns:vm="clr-namespace:Recipes.ViewModels"
+             x:DataType="vm:StartingPageViewModel"
              Title="{Binding Title}">
     <ScrollView>
         <Grid Margin="5">
@@ -25,7 +27,7 @@
                     Text="{Binding SearchQuery}"
                     Margin="0,5,0,5"
                     SearchCommand="{Binding SearchCommand}"
-                    SearchCommandParameter="{Binding Text, Source={x:Reference searchBar}}"/>
+                    SearchCommandParameter="{Binding Text, Source={x:Reference searchBar}, x:DataType=SearchBar}"/>
 
             <Grid Grid.Column="0" Grid.Row="2" Margin="20,5">
                 <Grid.ColumnDefinitions>


### PR DESCRIPTION
## Description

This PR updates the app to .NET9, but more importantly, it makes necessary changes to achieve AOT/trim compatibility making the app compatible with NativeAOT (and in general `TrimMode=Full` mode) when targeting iOS platforms.

## Initial state

The app initially produced 124 warnings (list of warnings: https://gist.github.com/ivanpovazan/8349040163c30f481b4d4f48ceb301a6) , due to the fact that it did not use:
- Source-generated JSON serialization
- IQueryAttributable interface instead of QueryPropertyAttribute
- Typed bindings

When doing the code review, you can follow the commit history as I was fixing each warning group one-by-one.

## Current state

- When using dotnet SDK: `9.0.100-preview.3.24204.13` 
and MAUI version: `9.0.0-preview.3.10457/9.0.100-preview.3`

    The app produces 9 warnings, where all of the warnings come from the framework it self:
    ```
  Recipes net9.0-ios succeeded with 9 warning(s) (34.2s) → bin/Release/net9.0-ios/ios-arm64/Recipes.dll
    D:\a\_work\1\s\src\Controls\src\Core\BindingExpression.cs(323): Trim analysis warning IL2070: Microsoft.Maui.Controls.BindingExpression.SetupPart(TypeInfo,BindingExpression.BindingExpressionPart): 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicMethods', 'DynamicallyAccessedMemberTypes.NonPublicMethods' in call to 'System.Reflection.TypeInfo.GetDeclaredMethod(String)'. The parameter '#0' of method 'Microsoft.Maui.Controls.BindingExpression.SetupPart(TypeInfo,BindingExpression.BindingExpressionPart)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
    D:\a\_work\1\s\src\Controls\src\Core\BindingExpression.cs(324): Trim analysis warning IL2070: Microsoft.Maui.Controls.BindingExpression.SetupPart(TypeInfo,BindingExpression.BindingExpressionPart): 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicMethods', 'DynamicallyAccessedMemberTypes.NonPublicMethods' in call to 'System.Reflection.TypeInfo.GetDeclaredMethod(String)'. The parameter '#0' of method 'Microsoft.Maui.Controls.BindingExpression.SetupPart(TypeInfo,BindingExpression.BindingExpressionPart)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
    D:\a\_work\1\s\src\Controls\src\Core\BindingExpression.cs(371): Trim analysis warning IL2070: Microsoft.Maui.Controls.BindingExpression.SetupPart(TypeInfo,BindingExpression.BindingExpressionPart): 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicProperties', 'DynamicallyAccessedMemberTypes.NonPublicProperties' in call to 'System.Reflection.TypeInfo.GetDeclaredProperty(String)'. The parameter '#0' of method 'Microsoft.Maui.Controls.BindingExpression.SetupPart(TypeInfo,BindingExpression.BindingExpressionPart)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
    D:\a\_work\1\s\src\Controls\src\Core\BindingExpression.cs(390): Trim analysis warning IL2070: Microsoft.Maui.Controls.BindingExpression.SetupPart(TypeInfo,BindingExpression.BindingExpressionPart): 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicFields', 'DynamicallyAccessedMemberTypes.NonPublicFields' in call to 'System.Reflection.TypeInfo.GetDeclaredField(String)'. The parameter '#0' of method 'Microsoft.Maui.Controls.BindingExpression.SetupPart(TypeInfo,BindingExpression.BindingExpressionPart)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
    D:\a\_work\1\s\src\Controls\src\Core\BindingExpression.cs(391): Trim analysis warning IL2070: Microsoft.Maui.Controls.BindingExpression.SetupPart(TypeInfo,BindingExpression.BindingExpressionPart): 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.Interfaces' in call to 'System.Reflection.TypeInfo.ImplementedInterfaces.get'. The parameter '#0' of method 'Microsoft.Maui.Controls.BindingExpression.SetupPart(TypeInfo,BindingExpression.BindingExpressionPart)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
    D:\a\_work\1\s\src\Controls\src\Core\BindingExpression.cs(256): Trim analysis warning IL2070: Microsoft.Maui.Controls.BindingExpression.GetIndexer(TypeInfo,String,String): 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicProperties', 'DynamicallyAccessedMemberTypes.NonPublicProperties' in call to 'System.Reflection.TypeInfo.DeclaredProperties.get'. The parameter '#0' of method 'Microsoft.Maui.Controls.BindingExpression.GetIndexer(TypeInfo,String,String)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
    D:\a\_work\1\s\src\Controls\src\Core\BindingExpression.cs(269): Trim analysis warning IL2070: Microsoft.Maui.Controls.BindingExpression.GetIndexer(TypeInfo,String,String): 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicProperties', 'DynamicallyAccessedMemberTypes.NonPublicProperties' in call to 'System.Reflection.TypeInfo.DeclaredProperties.get'. The parameter '#0' of method 'Microsoft.Maui.Controls.BindingExpression.GetIndexer(TypeInfo,String,String)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
    D:\a\_work\1\s\src\Controls\src\Core\BindingExpression.cs(280): Trim analysis warning IL2070: Microsoft.Maui.Controls.BindingExpression.GetIndexer(TypeInfo,String,String): 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicProperties', 'DynamicallyAccessedMemberTypes.NonPublicProperties' in call to 'System.Reflection.TypeInfo.DeclaredProperties.get'. The parameter '#0' of method 'Microsoft.Maui.Controls.BindingExpression.GetIndexer(TypeInfo,String,String)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
    D:\a\_work\1\s\src\Controls\src\Core\BindingExpression.cs(295): Trim analysis warning IL2070: Microsoft.Maui.Controls.BindingExpression.GetIndexer(TypeInfo,String,String): 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.Interfaces' in call to 'System.Reflection.TypeInfo.ImplementedInterfaces.get'. The parameter '#0' of method 'Microsoft.Maui.Controls.BindingExpression.GetIndexer(TypeInfo,String,String)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
    ```

- When using the MAUI at: https://github.com/dotnet/maui/commit/000f24b07057f7dbe85999cbae95cb5b110d288b

    The app produces 1 warning:
    ```
    Recipes net9.0-ios succeeded with 1 warning(s) (33.5s) → bin/Release/net9.0-ios/ios-arm64/Recipes.dll
    /Users/ivan/repos/maui/src/Controls/src/Xaml/MarkupExtensions/BindingExtension.cs(25): Trim analysis warning IL2026: Microsoft.Maui.Controls.Xaml.BindingExtension.Microsoft.Maui.Controls.Xaml.IMarkupExtension<Microsoft.Maui.Controls.BindingBase>.ProvideValue(IServiceProvider): Using member 'Microsoft.Maui.Controls.Binding.Binding(String,BindingMode,IValueConverter,Object,String,Object)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. Using bindings with string paths is not trim safe. Use expression-based binding instead.
    ```

## Testing

I tested the app on iOS device with both runtimes:
- MonoAOT: `dotnet publish -f net9.0-ios -r ios-arm64 -p:TrimmerSingleWarn=false -t:Run`
- NativeAOT: `dotnet publish -f net9.0-ios -r ios-arm64 -p:TrimmerSingleWarn=false -p:PublishAot=true -p:PublishAotUsingRuntimePack=true -t:Run`

### NOTE

I marked the PR as `DRAFT` as I am not that familiar with the code it self, but tried to adapt it to get rid of all the trim warnings, so please take that into account when doing the review. 

The goal is to reach 0 warnings and verify the app functionality (manually or through automated UI testing).

--- 

/cc: @PureWeen  @simonrozsival 