### PR TITLE
Add an async option for the iOS Voiceover and include message for Search Results

### DIFF
--- a/WhatToEat/App.xaml.cs
+++ b/WhatToEat/App.xaml.cs
@@ -9,6 +9,7 @@ public partial class App : Microsoft.Maui.Controls.Application
     {
 			InitializeComponent();
         DependencyService.Register<MockDataStore>();
+        DependencyService.Register<IAsyncAnnouncement, SemanticScreenReaderAsyncImplementation>();
 			MainPage = new AppShell();
 		}
 }

--- a/WhatToEat/App.xaml.cs
+++ b/WhatToEat/App.xaml.cs
@@ -9,7 +9,9 @@ public partial class App : Microsoft.Maui.Controls.Application
     {
 			InitializeComponent();
         DependencyService.Register<MockDataStore>();
+#if IOS
         DependencyService.Register<IAsyncAnnouncement, SemanticScreenReaderAsyncImplementation>();
+#endif
 			MainPage = new AppShell();
 		}
 }

--- a/WhatToEat/App.xaml.cs
+++ b/WhatToEat/App.xaml.cs
@@ -1,17 +1,28 @@
-﻿using Recipes.Services;
+﻿using Recipes.Models;
+using Recipes.Services;
 
 namespace Recipes;
 
 public partial class App : Microsoft.Maui.Controls.Application
 {
+	public static IServiceProvider ServiceProvider { get; private set; }
 
     public App()
     {
-			InitializeComponent();
-        DependencyService.Register<MockDataStore>();
+		InitializeComponent();
+
+		var serviceCollection = new ServiceCollection();
+		ConfigureServices(serviceCollection);
+		ServiceProvider = serviceCollection.BuildServiceProvider();
+
+		MainPage = new AppShell();
+	}
+
+	void ConfigureServices(IServiceCollection services)
+	{
+		services.AddSingleton<IDataStore<Item>, MockDataStore>();
 #if IOS
-        DependencyService.Register<IAsyncAnnouncement, SemanticScreenReaderAsyncImplementation>();
+		services.AddSingleton<IAsyncAnnouncement, SemanticScreenReaderAsyncImplementation>();
 #endif
-			MainPage = new AppShell();
-		}
+	}
 }

--- a/WhatToEat/MauiProgram.cs
+++ b/WhatToEat/MauiProgram.cs
@@ -18,10 +18,6 @@ namespace Recipes
 #endif
                     });
                 });
-
-#if IOS
-            builder.Services.AddSingleton<IAsyncAnnouncement, SemanticScreenReaderAsyncImplementation>();
-#endif
             return builder.Build();
         }
     }

--- a/WhatToEat/MauiProgram.cs
+++ b/WhatToEat/MauiProgram.cs
@@ -19,7 +19,9 @@ namespace Recipes
                     });
                 });
 
+#if IOS
             builder.Services.AddSingleton<IAsyncAnnouncement, SemanticScreenReaderAsyncImplementation>();
+#endif
             return builder.Build();
         }
     }

--- a/WhatToEat/MauiProgram.cs
+++ b/WhatToEat/MauiProgram.cs
@@ -1,4 +1,6 @@
-﻿namespace Recipes
+﻿using Recipes.Services;
+
+namespace Recipes
 {
     public class MauiProgram
     {
@@ -17,6 +19,7 @@
                     });
                 });
 
+            builder.Services.AddSingleton<IAsyncAnnouncement, SemanticScreenReaderAsyncImplementation>();
             return builder.Build();
         }
     }

--- a/WhatToEat/Platforms/iOS/SemanticScreenReaderAsyncImplementation.cs
+++ b/WhatToEat/Platforms/iOS/SemanticScreenReaderAsyncImplementation.cs
@@ -28,16 +28,12 @@ public class SemanticScreenReaderAsyncImplementation : IAsyncAnnouncement
         
         NSNotificationCenter.DefaultCenter.RemoveObserver(Token);
         Token = null;
+        announcementCompletionSource = null;
     }
 
     private void AnnouncementDidFinish(NSNotification notification)
     {
-        var wasSuccessful = notification.UserInfo["UIAccessibilityAnnouncementKeyWasSuccessful"] as NSNumber;
-
-        if (wasSuccessful != null && announcementCompletionSource != null)
-        {
-            announcementCompletionSource.TrySetResult(wasSuccessful.BoolValue);
-        }
+        announcementCompletionSource.TrySetResult(true);
     }
 
     public void Announce(string text)

--- a/WhatToEat/Platforms/iOS/SemanticScreenReaderAsyncImplementation.cs
+++ b/WhatToEat/Platforms/iOS/SemanticScreenReaderAsyncImplementation.cs
@@ -1,0 +1,68 @@
+﻿using Foundation;
+using UIKit;
+using System.Threading.Tasks;
+using Recipes.Services;
+
+[assembly: Dependency(typeof(Recipes.SemanticScreenReaderAsyncImplementation))]
+namespace Recipes;
+
+public class SemanticScreenReaderAsyncImplementation : IAsyncAnnouncement
+{
+    static NSObject Token;
+    private TaskCompletionSource<bool> announcementCompletionSource;
+
+    public void AddNotification()
+    {
+        if (Token != null)
+            return;
+        
+        Token = NSNotificationCenter.DefaultCenter.AddObserver(
+            new NSString("UIAccessibilityAnnouncementDidFinishNotification"),
+            AnnouncementDidFinish);
+    }
+
+    public void RemoveNotification()
+    {
+        if (Token == null)
+            return;
+        
+        NSNotificationCenter.DefaultCenter.RemoveObserver(Token);
+        Token = null;
+    }
+
+    private void AnnouncementDidFinish(NSNotification notification)
+    {
+        var wasSuccessful = notification.UserInfo["UIAccessibilityAnnouncementKeyWasSuccessful"] as NSNumber;
+
+        if (wasSuccessful != null && announcementCompletionSource != null)
+        {
+            announcementCompletionSource.TrySetResult(wasSuccessful.BoolValue);
+        }
+    }
+
+    public void Announce(string text)
+    {
+        if (!UIAccessibility.IsVoiceOverRunning)
+            return;
+
+        UIAccessibility.PostNotification(UIAccessibilityPostNotification.Announcement, new NSString(text));
+    }
+
+    public async Task AnnounceAsync(string text)
+    {
+        AddNotification();
+
+        if (!UIAccessibility.IsVoiceOverRunning)
+            return;
+
+        announcementCompletionSource = new TaskCompletionSource<bool>();
+
+        await Task.Delay(100);
+        UIAccessibility.PostNotification(UIAccessibilityPostNotification.Announcement, new NSString(text));
+
+        // Wait until the announcement is finished
+        await announcementCompletionSource.Task;
+
+        RemoveNotification();
+    }
+}

--- a/WhatToEat/Recipes.csproj
+++ b/WhatToEat/Recipes.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<MajorFrameworkVersion>9.0</MajorFrameworkVersion>
+		<MajorFrameworkVersion>8.0</MajorFrameworkVersion>
 		<TargetFrameworks>net$(MajorFrameworkVersion)-android;net$(MajorFrameworkVersion)-ios;net$(MajorFrameworkVersion)-maccatalyst</TargetFrameworks>
 		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net$(MajorFrameworkVersion)-windows10.0.19041.0</TargetFrameworks>
 		<OutputType>Exe</OutputType>

--- a/WhatToEat/Services/AnnouncementHelper.cs
+++ b/WhatToEat/Services/AnnouncementHelper.cs
@@ -1,0 +1,14 @@
+﻿namespace Recipes.Services;
+
+public static class AnnouncementHelper
+{
+    public static async Task Announce(string recipeName)
+    {
+#if IOS
+        var _semanticScreenReader = DependencyService.Get<IAsyncAnnouncement>();
+        await _semanticScreenReader.AnnounceAsync(recipeName);
+#else
+        SemanticScreenReader.Announce(recipeName);
+#endif
+    }
+}

--- a/WhatToEat/Services/AnnouncementHelper.cs
+++ b/WhatToEat/Services/AnnouncementHelper.cs
@@ -5,7 +5,7 @@ public static class AnnouncementHelper
     public static async Task Announce(string recipeName)
     {
 #if IOS
-        var _semanticScreenReader = DependencyService.Get<IAsyncAnnouncement>();
+        var _semanticScreenReader = App.ServiceProvider.GetService<IAsyncAnnouncement>();
         await _semanticScreenReader.AnnounceAsync(recipeName);
 #else
         SemanticScreenReader.Announce(recipeName);

--- a/WhatToEat/Services/IAsyncAnnouncement.cs
+++ b/WhatToEat/Services/IAsyncAnnouncement.cs
@@ -1,0 +1,6 @@
+﻿namespace Recipes.Services;
+
+public interface IAsyncAnnouncement
+{
+    Task AnnounceAsync(string text);
+}

--- a/WhatToEat/ViewModels/BaseViewModel.cs
+++ b/WhatToEat/ViewModels/BaseViewModel.cs
@@ -8,7 +8,7 @@ namespace Recipes.ViewModels
 {
     public class BaseViewModel : INotifyPropertyChanged
     {
-        public IDataStore<Item> DataStore => DependencyService.Get<IDataStore<Item>>();
+        public IDataStore<Item> DataStore => App.ServiceProvider.GetService<IDataStore<Item>>();
 
         bool isBusy = false;
         public bool IsBusy

--- a/WhatToEat/ViewModels/EditRecipeViewModel.cs
+++ b/WhatToEat/ViewModels/EditRecipeViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics;
 using Recipes.Models;
+using Recipes.Services;
 
 namespace Recipes.ViewModels
 {
@@ -134,7 +135,7 @@ namespace Recipes.ViewModels
         {
             await DataStore.DeleteItemAsync(_id);
 
-            SemanticScreenReader.Announce(RecipeName + " recipe deleted.");
+            await AnnouncementHelper.Announce(RecipeName + " recipe deleted.");
 
             await Shell.Current.GoToAsync("../..");
         }
@@ -160,7 +161,7 @@ namespace Recipes.ViewModels
 
             await DataStore.UpdateItemAsync(NewRecipe);
 
-            SemanticScreenReader.Announce(RecipeName + " recipe updated.");
+            await AnnouncementHelper.Announce(RecipeName + " recipe updated.");
 
             await Shell.Current.GoToAsync("..");
         }

--- a/WhatToEat/ViewModels/NewRecipeViewModel.cs
+++ b/WhatToEat/ViewModels/NewRecipeViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using Recipes.Models;
+using Recipes.Services;
 
 namespace Recipes.ViewModels
 {
@@ -97,7 +98,7 @@ namespace Recipes.ViewModels
 
             await DataStore.AddItemAsync(NewRecipe);
 
-            SemanticScreenReader.Announce(RecipeName + " recipe added.");
+            await AnnouncementHelper.Announce(RecipeName + " recipe added.");
 
             // This will pop the current page off the navigation stack
             await Shell.Current.GoToAsync("..");

--- a/WhatToEat/ViewModels/SearchResultsViewModel.cs
+++ b/WhatToEat/ViewModels/SearchResultsViewModel.cs
@@ -1,3 +1,4 @@
+﻿using Recipes.Services;
 using Recipes.Views;
 
 namespace Recipes.ViewModels
@@ -25,7 +26,6 @@ namespace Recipes.ViewModels
 
             ItemTapped = new Command<Hit>(OnItemSelected);
             SearchCommand = new Command(async () => await OnSearch());
-
 		}
 
         public void ApplyQueryAttributes(IDictionary<string, object> query)
@@ -110,6 +110,8 @@ namespace Recipes.ViewModels
                     NoResultsLabel = $"Sorry! We couldn't find any recipes for {SearchQuery}. Try searching for a different recipe!";
                     NoResultsLabelVisible = true;
                     SearchResultsVisible = false;
+
+                    await AnnouncementHelper.Announce(NoResultsLabel);
                 }
                 else
                 {
@@ -123,6 +125,8 @@ namespace Recipes.ViewModels
 
                     RecipeData = recipeData;
                     AppShell.Data = RecipeData;
+
+                    await AnnouncementHelper.Announce("Result found.");
                 }
             }
         }

--- a/WhatToEat/Views/EditRecipePage.xaml.cs
+++ b/WhatToEat/Views/EditRecipePage.xaml.cs
@@ -1,4 +1,5 @@
-﻿using Recipes.ViewModels;
+﻿using Recipes.Services;
+using Recipes.ViewModels;
 
 namespace Recipes.Views
 {
@@ -19,8 +20,7 @@ namespace Recipes.Views
             else
 				increasedOrDecreased = "Rating decreased to ";
 
-			await Task.Delay(100);
-			SemanticScreenReader.Announce(increasedOrDecreased + SemanticProperties.GetDescription(ratingLabel));
+            await AnnouncementHelper.Announce(increasedOrDecreased + SemanticProperties.GetDescription(ratingLabel));
 		}
     }
 }

--- a/WhatToEat/Views/NewRecipePage.xaml.cs
+++ b/WhatToEat/Views/NewRecipePage.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using Recipes.Models;
+using Recipes.Services;
 using Recipes.ViewModels;
 
 namespace Recipes.Views
@@ -22,8 +23,7 @@ namespace Recipes.Views
 			else
 				increasedOrDecreased = "Rating decreased to ";
 
-			await Task.Delay(100);
-			SemanticScreenReader.Announce(increasedOrDecreased + SemanticProperties.GetDescription(ratingLabel));
+            await AnnouncementHelper.Announce(increasedOrDecreased + SemanticProperties.GetDescription(ratingLabel));
 		}
 	}
 }

--- a/WhatToEat/Views/RecipeDetailPage.xaml.cs
+++ b/WhatToEat/Views/RecipeDetailPage.xaml.cs
@@ -1,4 +1,5 @@
-﻿using Recipes.ViewModels;
+﻿using Recipes.Services;
+using Recipes.ViewModels;
 
 namespace Recipes.Views
 {
@@ -20,7 +21,7 @@ namespace Recipes.Views
 
         async void OpenUrl(object sender, EventArgs e)
         {
-            SemanticScreenReader.Announce("Exiting app. Entering browser to view full recipe.");
+            await AnnouncementHelper.Announce("Exiting app. Entering browser to view full recipe.");
             await Launcher.OpenAsync(_viewModel.RecipeUrl);
         }
 

--- a/WhatToEat/Views/SearchResultDetailPage.xaml.cs
+++ b/WhatToEat/Views/SearchResultDetailPage.xaml.cs
@@ -1,4 +1,5 @@
-﻿using Recipes.ViewModels;
+﻿using Recipes.Services;
+using Recipes.ViewModels;
 
 namespace Recipes.Views
 {
@@ -18,7 +19,7 @@ namespace Recipes.Views
 
         async void OpenUrl(object sender, EventArgs e)
         {
-            SemanticScreenReader.Announce("Exiting app. Entering browser to view full recipe.");
+            await AnnouncementHelper.Announce("Exiting app. Entering browser to view full recipe.");
             await Launcher.OpenAsync(_viewModel.Hit.Recipe.RecipeUrl);
         }
 
@@ -32,8 +33,7 @@ namespace Recipes.Views
 
         async void AddItem_Clicked(object sender, System.EventArgs e)
         {
-			await Task.Delay(100);
-			SemanticScreenReader.Announce(alertMessage);
+            await AnnouncementHelper.Announce(alertMessage);
 
             // TODO MAUI
             //var messageOptions = new MessageOptions


### PR DESCRIPTION
This PR adds an async Announce service on iOS for the VoiceOver feature. The issue is that there are important announcements to make such as items added to a database, but when other things are going on such as a page changing, these announcements get interrupted. One solution is to await the announcement calls on iOS so that the announcement can finish and then move on to the other system announcements.

The other change in this PR is to send an announcement based on if the search results found matches or not.  

Fixes: 
* https://github.com/dotnet/maui/issues/23001
* https://github.com/dotnet/maui/issues/22971
* https://github.com/dotnet/maui/issues/22845
* https://github.com/dotnet/maui/issues/23002