### PR TITLE
Change Ingredient text to use a grid and add wordWrap

### DIFF
--- a/WhatToEat/Views/RecipeDetailPage.xaml
+++ b/WhatToEat/Views/RecipeDetailPage.xaml
@@ -27,10 +27,10 @@
                 <StackLayout  BindableLayout.ItemsSource="{Binding IngredientCheckList}" Padding="15,0" IsVisible="{Binding IngredientsVisible}">
                     <BindableLayout.ItemTemplate>
                         <DataTemplate>
-                            <StackLayout Orientation="Horizontal">
+                            <Grid ColumnDefinitions="*,7*">
                                 <CheckBox SemanticProperties.Description="{Binding IngredientItem, x:DataType=models:Ingredient}" Color="{AppThemeBinding Dark=White, Light={StaticResource Primary}}" IsChecked="{Binding IngredientChecked}" HeightRequest="50" WidthRequest="50"/>
-                                <Label AutomationProperties.IsInAccessibleTree="False" Text="{Binding IngredientItem, x:DataType=models:Ingredient}"  VerticalOptions="Center"/>
-                            </StackLayout>
+                                <Label AutomationProperties.IsInAccessibleTree="False" Text="{Binding IngredientItem, x:DataType=models:Ingredient}"  VerticalOptions="Center" LineBreakMode="WordWrap" Grid.Column="1"/>
+                            </Grid>
                         </DataTemplate>
                     </BindableLayout.ItemTemplate>
                 </StackLayout>


### PR DESCRIPTION
The issue here is that the text for the ingredients was in a HorizontalStackLayout so when the text size increased, the text would not continue onto the next line.

Fixes: 
* https://github.com/dotnet/maui/issues/22969