### PR TITLE
Fix Control Type on search results on Mac

### DIFF
--- a/WhatToEat/Views/SearchResultsPage.xaml
+++ b/WhatToEat/Views/SearchResultsPage.xaml
@@ -39,8 +39,10 @@
                           RowDefinitions="*" 
                           ColumnDefinitions="*">
 
-                        <Grid>
-                            <Image Source="{Binding Recipe.ImageUrl, x:DataType=recipes:Hit}" Aspect="AspectFill" VerticalOptions="Fill" HorizontalOptions="Fill" AutomationProperties.IsInAccessibleTree="False"/>
+                        <Button SemanticProperties.Description="{Binding Recipe.RecipeName, x:DataType=recipes:Hit}" />
+
+                        <Grid AutomationProperties.ExcludedWithChildren="True">
+                            <Image Source="{Binding Recipe.ImageUrl, x:DataType=recipes:Hit}" Aspect="AspectFill" VerticalOptions="Fill" HorizontalOptions="Fill"/>
                             <Label x:Name="recipeName"
                                    Padding="5"
                                    HorizontalOptions="Fill" 
@@ -52,12 +54,8 @@
                                    LineBreakMode="WordWrap" 
                                    MaxLines="2"
                                    HeightRequest="80"
-                                   FontSize="16"
-                                   AutomationProperties.IsInAccessibleTree="False"/>
+                                   FontSize="16"/>
                         </Grid>
-
-                        <Button SemanticProperties.Description="{Binding Recipe.RecipeName, x:DataType=recipes:Hit}" />
-
                     </Grid>
                 </DataTemplate>
             </CollectionView.ItemTemplate>

--- a/WhatToEat/Views/SearchResultsPage.xaml
+++ b/WhatToEat/Views/SearchResultsPage.xaml
@@ -33,7 +33,7 @@
             </CollectionView.ItemsLayout>
             <CollectionView.ItemTemplate>
                 <DataTemplate>
-                    <Grid SemanticProperties.Description="{Binding Recipe.RecipeName, x:DataType=recipes:Hit}"
+                    <Grid
                           HandlerChanged="OnImageHandlerChanged" 
                           HeightRequest="220"
                           RowDefinitions="*" 
@@ -52,8 +52,11 @@
                                    LineBreakMode="WordWrap" 
                                    MaxLines="2"
                                    HeightRequest="80"
-                                   FontSize="16"/>
+                                   FontSize="16"
+                                   AutomationProperties.IsInAccessibleTree="False"/>
                         </Grid>
+
+                        <Button SemanticProperties.Description="{Binding Recipe.RecipeName, x:DataType=recipes:Hit}" />
 
                     </Grid>
                 </DataTemplate>

--- a/WhatToEat/Views/SearchResultsPage.xaml
+++ b/WhatToEat/Views/SearchResultsPage.xaml
@@ -39,9 +39,9 @@
                           RowDefinitions="*" 
                           ColumnDefinitions="*">
 
-                        <Grid AutomationProperties.ExcludedWithChildren="True">
-                            <Image Source="{Binding Recipe.ImageUrl, x:DataType=recipes:Hit}" Aspect="AspectFill" VerticalOptions="Fill" HorizontalOptions="Fill"/>
-                            <Label x:Name="recipeName"
+                        <Grid AutomationProperties.ExcludedWithChildren="True" RowDefinitions="*, auto">
+                            <Image Grid.Row="0" Source="{Binding Recipe.ImageUrl, x:DataType=recipes:Hit}" Aspect="AspectFill" VerticalOptions="Fill" HorizontalOptions="Fill"/>
+                            <Label Grid.Row="1" x:Name="recipeName"
                                    Padding="5"
                                    HorizontalOptions="Fill" 
                                    VerticalOptions="End"

--- a/WhatToEat/Views/SearchResultsPage.xaml
+++ b/WhatToEat/Views/SearchResultsPage.xaml
@@ -33,13 +33,11 @@
             </CollectionView.ItemsLayout>
             <CollectionView.ItemTemplate>
                 <DataTemplate>
-                    <Grid
+                    <Grid SemanticProperties.Description="{Binding Recipe.RecipeName, x:DataType=recipes:Hit}"
                           HandlerChanged="OnImageHandlerChanged" 
                           HeightRequest="220"
                           RowDefinitions="*" 
                           ColumnDefinitions="*">
-
-                        <Button SemanticProperties.Description="{Binding Recipe.RecipeName, x:DataType=recipes:Hit}" />
 
                         <Grid AutomationProperties.ExcludedWithChildren="True">
                             <Image Source="{Binding Recipe.ImageUrl, x:DataType=recipes:Hit}" Aspect="AspectFill" VerticalOptions="Fill" HorizontalOptions="Fill"/>
@@ -56,6 +54,11 @@
                                    HeightRequest="80"
                                    FontSize="16"/>
                         </Grid>
+
+                        <!-- This TapGestureRecognizer ensures that the grid is treated as a button for accessibility purposes on iOS -->
+                        <Grid.GestureRecognizers>
+                            <TapGestureRecognizer/>
+                        </Grid.GestureRecognizers>
                     </Grid>
                 </DataTemplate>
             </CollectionView.ItemTemplate>


### PR DESCRIPTION
The issue lies in that the SemanticProperty.Description is set on the outer grid for this CollectionView.ItemTemplate below. The label was getting set correctly, but the Accessibility Inspector cannot know what type derives from Grid or that our purpose for the consumer is to use this grid as a button. In Android, the screenreader reads which row and column of the collectionview the item is in and the before and after from this change gives the same behavior. In iOS, we go from "Cripsy Egg" to "Crispy Egg button". In Catalyst, the screen reader announces we are in a group but just says Crispy Egg. After this change, the screen reader still announces we are in a group and says "Crispy Egg Button" plus the following message: 
![image](https://github.com/user-attachments/assets/a0a38a69-18e8-46e8-8640-dd2141f6de35)


```xaml
            <CollectionView.ItemTemplate>
                <DataTemplate>
                    <Grid SemanticProperties.Description="{Binding Recipe.RecipeName}"
                          HandlerChanged="OnImageHandlerChanged" 
                          HeightRequest="220"
                          RowDefinitions="*" 
                          ColumnDefinitions="*">

                        <Grid>
                            <Image Source="{Binding Recipe.ImageUrl}" Aspect="AspectFill" VerticalOptions="Fill" HorizontalOptions="Fill" AutomationProperties.IsInAccessibleTree="False"/>
                            <Label x:Name="recipeName"
                                   Padding="5"
                                   HorizontalOptions="Fill" 
                                   VerticalOptions="End"
                                   VerticalTextAlignment="Start"
                                   HorizontalTextAlignment="Center"
                                   Text="{Binding Recipe.RecipeName}"
                                   Style="{StaticResource RecipeNameStyle}"
                                   LineBreakMode="WordWrap" 
                                   MaxLines="2"
                                   HeightRequest="80"
                                   FontSize="16"/>
                        </Grid>

                    </Grid>
                </DataTemplate>
            </CollectionView.ItemTemplate>
```

Before: 
![image](https://github.com/user-attachments/assets/e3a78c09-ef99-4cdd-b3b1-eb84bce0d6c2)


After: 
![image](https://github.com/user-attachments/assets/603400e7-3936-4f85-a6bb-92d9d99f78aa)


Fixes:
* https://github.com/dotnet/maui/issues/22962